### PR TITLE
Added of the pointer to default tile and events on the lateral button

### DIFF
--- a/inc/ui/ui.h
+++ b/inc/ui/ui.h
@@ -106,6 +106,9 @@ typedef struct {
   /* Pointer to current tile. */
   tile_t *p_current_tile;
 
+  /* Pointer to default tile. */
+  tile_t *p_default_tile;
+
   /* Pointer to a modal box. */
   modal_t *p_modal;
 
@@ -119,7 +122,9 @@ typedef struct {
 
 /* Main UI */
 void ui_init(void);
+void ui_set_default_tile(tile_t *p_tile);
 void ui_select_tile(tile_t *p_tile);
+void ui_default_tile();
 void ui_process_events(void);
 void ui_set_modal(modal_t *p_modal);
 void ui_unset_modal(void);

--- a/ui/ui.c
+++ b/ui/ui.c
@@ -18,8 +18,9 @@ void ui_init(void)
   /* Initialize the touch screen. */
   twatch_touch_init();
 
-  /* Set current tile as none. */
+  /* Set current and default tiles as none. */
   g_ui.p_current_tile = NULL;
+  g_ui.p_default_tile = NULL;
 
   /* Set animation state and parameters. */
   g_ui.state = UI_STATE_IDLE;
@@ -31,6 +32,17 @@ void ui_init(void)
 }
 
 
+void ui_set_default_tile(tile_t *p_tile)
+{
+  /* Set default tile. */
+  g_ui.p_default_tile = p_tile;
+
+  /* Reset offsets in order to display this tile. */
+  g_ui.p_default_tile->offset_x = 0;
+  g_ui.p_default_tile->offset_y = 0;
+}
+
+
 /**
  * @brief: Select the current tile
  * @param p_tile: pointer to a `tile_t` structure (the tile to select)
@@ -38,6 +50,10 @@ void ui_init(void)
 
 void ui_select_tile(tile_t *p_tile)
 {
+  /* Set default tile as p_tile. */
+  if (g_ui.p_default_tile == NULL)
+    ui_set_default_tile(p_tile);
+
   if (g_ui.p_current_tile != NULL)
   {
     /* Send TE_ENTER to current tile. */
@@ -65,6 +81,15 @@ void ui_select_tile(tile_t *p_tile)
     0,
     0
   );
+}
+
+void ui_default_tile()
+{
+  if (g_ui.p_default_tile == NULL)
+    return;
+
+  /* Select our default tile. */
+  ui_select_tile(g_ui.p_default_tile);
 }
 
 
@@ -267,6 +292,17 @@ void IRAM_ATTR ui_process_events(void)
   /* Has lateral button been short-pressed ? */
   if (twatch_pmu_is_userbtn_pressed())
   {
+    if (g_ui.p_current_tile == g_ui.p_default_tile)
+    {
+      printf("[userbtn] Sleep mode enabled\r\n");
+      twatch_pmu_deepsleep();
+    }
+    else
+    {
+      printf("[userbtn] Return to our default tile\r\n");
+      ui_default_tile();
+    }
+ 
     /* Forward event to the current tile. */
     tile_send_event(
       g_ui.p_current_tile,
@@ -276,7 +312,6 @@ void IRAM_ATTR ui_process_events(void)
       0
     );
   }
-
 
   /* Refresh screen. */
   st7789_blank();


### PR DESCRIPTION
This modification allows to remove the latency when pressing the lateral button, it's not yet perfect but it works :).
I also add the possibility to choose and select the default tile which is initialized at startup with the ui_select_tile () function.

The side button allows you to do 2 actions:

- If we are on a tile different from the default one, we are redirected to it.
- If we are on the default tile, we put the watch on standby.

There is no modification to be made on the hackwatch repo, apart from updating the submodule ;)