### PR TITLE
Rotate screen

### DIFF
--- a/drivers/st7789.c
+++ b/drivers/st7789.c
@@ -39,8 +39,8 @@ ledc_channel_config_t backlight_config = {
   .timer_sel  = LEDC_TIMER_0
 };
 
-DRAM_ATTR static bool g_inv_x = true;
-DRAM_ATTR static bool g_inv_y = true;
+RTC_DATA_ATTR static bool g_inv_x = true;
+RTC_DATA_ATTR static bool g_inv_y = true;
 
 /* Drawing window. */
 DRAM_ATTR static int g_dw_x0 = 0;

--- a/hal/touch.c
+++ b/hal/touch.c
@@ -10,7 +10,7 @@ float velocity;
 int16_t dx,dy;
 double distance;
 int duration, touch_start_ms, touch_stop_ms;
-bool b_inverted=false;
+RTC_DATA_ATTR static bool b_inverted=false;
 
 /* b_touched: used by ISR to notify touch HAL some touch data need to be retrieved. */
 volatile bool b_touched = false;


### PR DESCRIPTION
Après le passage en deepsleep l'écran si configuré en rotation ne mémorise pas le choix au prochain réveil.
Modification de "b_inverted", "g_inv_x" et  "g_inv_y" pour être sauvegardé avec RTC_DATA_ATTR