### PR TITLE
Adding switch to deepsleep after a second period of inactivity

### DIFF
--- a/inc/ui/ui.h
+++ b/inc/ui/ui.h
@@ -124,6 +124,7 @@ typedef struct {
   screen_mode_t screen_mode;
   timer_config_t eco_timer;
   int eco_max_inactivity;
+  int eco_max_inactivity_to_deepsleep;
   bool b_inactivity_detected;
 
 } ui_t;

--- a/ui/ui.c
+++ b/ui/ui.c
@@ -65,6 +65,7 @@ void ui_init(void)
   g_ui.b_eco_mode_enabled = false;
   g_ui.b_inactivity_detected = false;
   g_ui.eco_max_inactivity = 15; /* Inactivity set to 15 sec by default. */
+  g_ui.eco_max_inactivity_to_deepsleep = 60; /* Second inactivity set to 60 by default */ 
   g_ui.eco_timer.divider = TIMER_DIVIDER;
   g_ui.eco_timer.counter_dir = TIMER_COUNT_UP;
   g_ui.eco_timer.counter_en = TIMER_PAUSE;
@@ -252,6 +253,18 @@ void ui_go_down(void)
   ui_swipe_up();
 }
 
+/**
+ * __ui_deepsleep_activate()
+ * 
+ * @brief: Activate the deepsleep mode
+ **/
+void __ui_deepsleep_activate()
+{
+  printf("[userbtn] Sleep mode enabled\r\n");
+  st7789_blank();
+  st7789_commit_fb();
+  twatch_pmu_deepsleep();
+}
 
 /**
  * ui_process_events()
@@ -360,14 +373,35 @@ void IRAM_ATTR ui_process_events(void)
       if (g_ui.b_inactivity_detected && g_ui.b_eco_mode_enabled)
       {
         printf("[eco] inactivity period detected\r\n");
-        if (g_ui.screen_mode == SCREEN_MODE_NORMAL)
+        
+        g_ui.b_inactivity_detected = false;
+
+        switch (g_ui.screen_mode)
         {
           /* Switch screen to dimmed mode. */
-          twatch_screen_set_backlight(100);
-          g_ui.screen_mode = SCREEN_MODE_DIMMED;
+          case SCREEN_MODE_NORMAL:
+            twatch_screen_set_backlight(100);
+            g_ui.screen_mode = SCREEN_MODE_DIMMED;
+
+            /* Activate second alarm for switch in deepsleep mode if necessary */
+            if (g_ui.eco_max_inactivity_to_deepsleep != 0)
+            {
+              timer_set_counter_value(TIMER_GROUP_1, TIMER_1, 0);
+              timer_set_alarm_value(TIMER_GROUP_1, TIMER_1, g_ui.eco_max_inactivity_to_deepsleep * TIMER_SCALE);
+              timer_start(TIMER_GROUP_1, TIMER_1);
+            }
+            else
+            {
+              timer_pause(TIMER_GROUP_1, TIMER_1);
+            }
+            break;
+
+          /* Switch screen to deepsleep */  
+          case SCREEN_MODE_DIMMED:
+            timer_pause(TIMER_GROUP_1, TIMER_1);
+            __ui_deepsleep_activate();
+            break;
         }
-        timer_pause(TIMER_GROUP_1, TIMER_1);
-        g_ui.b_inactivity_detected = false;
       }
     }
   }
@@ -377,10 +411,8 @@ void IRAM_ATTR ui_process_events(void)
   {
     if (g_ui.p_current_tile == g_ui.p_default_tile)
     {
-      printf("[userbtn] Sleep mode enabled\r\n");
-      st7789_blank();
-      st7789_commit_fb();
-      twatch_pmu_deepsleep();
+      /* Activate deepsleep */
+      __ui_deepsleep_activate();
     }
     else
     {


### PR DESCRIPTION
After the first activity period the screen turn into "dimmed mode" and after a second period of inactivity (60 by default) screen turn into "deepsleep mode"