### PR TITLE
Correction of the maximum value of a Lithium Ion battery

### DIFF
--- a/hal/pmu.c
+++ b/hal/pmu.c
@@ -276,9 +276,10 @@ int twatch_pmu_get_battery_level(void)
     voltage = axpxx_getBattVoltage();
     if (voltage < 3000.0)
       level = 0;
-    if (voltage > 4250.0)
+    if (voltage > 4200.0)
       level = 100;
-    level = ((voltage - 3000)*100)/1280;
+    else
+      level = ((voltage - 3000)*100)/1200;
   }
   
   return level;

--- a/hal/pmu.c
+++ b/hal/pmu.c
@@ -274,12 +274,11 @@ int twatch_pmu_get_battery_level(void)
   if (level < 0)
   {
     voltage = axpxx_getBattVoltage();
-    if (voltage < 3000.0)
+    level = ((voltage - 3000)*100)/1200;
+    if (level < 0)
       level = 0;
-    if (voltage > 4200.0)
+    if (level > 100)
       level = 100;
-    else
-      level = ((voltage - 3000)*100)/1200;
   }
   
   return level;

--- a/hal/pmu.c
+++ b/hal/pmu.c
@@ -274,7 +274,7 @@ int twatch_pmu_get_battery_level(void)
   if (level < 0)
   {
     voltage = axpxx_getBattVoltage();
-    level = ((voltage - 3000)*100)/1200;
+    level = ((voltage - 3200)*100)/1000;
     if (level < 0)
       level = 0;
     if (level > 100)


### PR DESCRIPTION
The maximum voltage of a lithium ion battery is 4.2V +/- 0.01V, when it is no longer charging mode the maximum value drops to about 94%.
I also corrected an error in the condition which did not take into account the min and max value of the level.