### PR TITLE
Fix #ifdef for twatch_pmu_vibration

### DIFF
--- a/hal/pmu.c
+++ b/hal/pmu.c
@@ -370,6 +370,8 @@ esp_err_t twatch_pmu_vibration(bool enable)
       AXP_GPIO_0,
       enable ? AXP_IO_OUTPUT_HIGH_MODE : AXP_IO_OUTPUT_LOW_MODE
     ) == AXP_PASS);
+  #else
+    return ESP_OK;
   #endif
 }
 


### PR DESCRIPTION
Thank you for the `twatch-lib` and the `hackwatch` projects :)

The code doesn't compile currently when used without CONFIG_TWATCH_V2.

I would guess for other versions, `twatch_pmu_vibration` should return `ESP_OK` without doing anything, but not really sure though.
Feel free to correct me if needed :)